### PR TITLE
Refactor and clean up bible_api.py, synoptic_table.py, test_make_tabl…

### DIFF
--- a/agreement/bible_api.py
+++ b/agreement/bible_api.py
@@ -11,25 +11,27 @@ def percent_encode(link):
 
 
 def get_verse(version, book, chapter, verse):
-    endpoint = "\
-https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${version}/books/${book}/chapters/${chapter}/verses/${verse}.json\
-"
-    endpoint = endpoint.replace("${version}", version)
-    endpoint = endpoint.replace("${book}", book)
-    endpoint = endpoint.replace("${chapter}", str(chapter))
-    endpoint = endpoint.replace("${verse}", str(verse))
+    endpoint = (
+        "https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles"
+        f"/{version}"
+        f"/books/{book}"
+        f"/chapters/{chapter}"
+        f"/verses/{verse}.json"
+    )
+
     with urllib.request.urlopen(percent_encode(endpoint)) as url:
         data = json.load(url)
     return data["text"]
 
 
 def get_chapter(version, book, chapter, start_verse, end_verse):
-    endpoint = "\
-https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${version}/books/${book}/chapters/${chapter}.json\
-"
-    endpoint = endpoint.replace("${version}", version)
-    endpoint = endpoint.replace("${book}", book)
-    endpoint = endpoint.replace("${chapter}", str(chapter))
+    endpoint = (
+        "https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles"
+        f"/{version}"
+        f"/books/{book}"
+        f"/chapters/{chapter}.json"
+    )
+
     with urllib.request.urlopen(percent_encode(endpoint)) as url:
         data = json.load(url)
     df = pd.json_normalize(data["data"])

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -3,87 +3,75 @@ from rich.console import Console
 from agreement.bible_api import get_chapter
 from agreement.color_scheme import ColorScheme, GoodacreColorScheme
 from agreement.config import get_report_path
-from agreement.synoptic_table import SynopticTable
+from agreement.synoptic_table import SynopticTable, Parallel
 import tests.config
 
+def run_example(table_title, passages, report_filename, **kwargs):
+    synoptic_table = SynopticTable(
+        table_title, passages,
+        **kwargs
+    )
+
+    synoptic_table.process_synopsis()
+    table = synoptic_table.table
+    print(table)
+    console = Console(record=True)
+    console.print(table)
+    html_path = get_report_path(report_filename)
+    console.save_html(html_path)
 
 def main():
-    synopticTable = SynopticTable(
+    run_example(
         "14 John's Preaching of Repentance",
         [
-            ["Matt. 3:7-10",
-             get_chapter("grc-byz1904", "καταματθαιον", 3, 7, 10)],
-            ["Luke 3:7-9", get_chapter("grc-byz1904", "καταλουκαν", 3, 7, 9)],
+            Parallel(title="Matt. 3:7-10", text=get_chapter("grc-byz1904", "καταματθαιον", 3, 7, 10), footer=""),
+            Parallel(title="Luke 3:7-9", text=get_chapter("grc-byz1904", "καταλουκαν", 3, 7, 9), footer="")
         ],
-        color_scheme=ColorScheme(None, "blue", "yellow", "green"),
-    )
-    table = synopticTable.table
-    console = Console(record=True)
-    console.print(table)
-    html_path = get_report_path("014-Matt+Luke.html")
-    console.save_html(html_path)
+        "014-Matt+Luke.html",
+        color_scheme = ColorScheme(None, "blue", "yellow", "green")
 
-    synopticTable = SynopticTable(
+    )
+
+
+    run_example(
         "68 On Judging (Log and Speck)",
         [
-            ["Matt. 7:3-5",
-             get_chapter("grc-byz1904", "καταματθαιον", 7, 3, 5)],
-            ["Luke 6:41-43",
-             get_chapter("grc-byz1904", "καταλουκαν", 6, 41, 43)],
+            Parallel(title="Matt. 7:3-5", text=get_chapter("grc-byz1904", "καταματθαιον", 7, 3, 5), footer=""),
+            Parallel(title="Luke 6:41-43", text=get_chapter("grc-byz1904", "καταλουκαν", 6, 41, 43), footer="")
         ],
+        "068-Matt+Luke.html"
     )
-    table = synopticTable.table
-    console = Console(record=True)
-    console.print(table)
-    html_path = get_report_path("068-Matt+Luke.html")
-    console.save_html(html_path)
 
-    synopticTable = SynopticTable(
+    run_example(
         "128 The Parable of the Mustard Seed (First Verse)",
         [
-            ["Mark 4:30", tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30],
-            ["Matt. 13:31", tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31],
-            ["Luke 13:18-19", tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19],
+            Parallel(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer=""),
+            Parallel(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer=""),
+            Parallel(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="")
         ],
-        color_scheme=ColorScheme(None, None, None, "yellow",
-                                 None, None, "green"),
+        "128-Mark+Matt+Luke.html",
+        color_scheme = ColorScheme(None, None, None, "yellow", None, None, "green")
     )
-    table = synopticTable.table
-    console = Console(record=True)
-    console.print(table)
-    html_path = get_report_path("128-Mark+Matt+Luke.html")
-    console.save_html(html_path)
 
-    synopticTable = SynopticTable(
+    run_example(
         "128 The Parable of the Mustard Seed (First Verse)",
         [
-            ["Matt. 13:31", tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31],
-            ["Mark 4:30", tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30],
-            ["Luke 13:18-19", tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19],
+            Parallel(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer=""),
+            Parallel(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer=""),
+            Parallel(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="")
         ],
-        color_scheme=GoodacreColorScheme(0, 1, 2)
+        "128-Matt+Mark+Luke.html",
+        color_scheme = GoodacreColorScheme(0, 1, 2)
     )
-    table = synopticTable.table
-    console = Console(record=True)
-    console.print(table)
-    html_path = get_report_path("128-Matt+Mark+Luke.html")
-    console.save_html(html_path)
 
-    synopticTable = SynopticTable(
+    run_example(
         "291 False Christs and False Prophets",
         [
-            ["Mark 13:21-23",
-             get_chapter("grc-byz1904", "καταμαρκον", 13, 21, 23)],
-            ["Matt. 24:23-25",
-             get_chapter("grc-byz1904", "καταματθαιον", 24, 23, 25)],
-        ],
+            Parallel(title="Mark 13:21-23", text=get_chapter("grc-byz1904", "καταμαρκον", 13, 21, 23), footer=""),
+            Parallel(title="Matt. 24:23-25", text=get_chapter("grc-byz1904", "καταματθαιον", 24, 23, 25), footer="")
+         ],
+        "291-Mark+Matt.svg"
     )
-    table = synopticTable.table
-    console = Console(record=True)
-    console.print(table)
-    svg_path = get_report_path("291-Mark+Matt.svg")
-    console.save_svg(svg_path)
-
 
 if __name__ == "__main__":
     main()

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -14,7 +14,6 @@ def run_example(table_title, passages, report_filename, **kwargs):
 
     synoptic_table.process_synopsis()
     table = synoptic_table.table
-    print(table)
     console = Console(record=True)
     console.print(table)
     html_path = get_report_path(report_filename)
@@ -31,7 +30,6 @@ def main():
         color_scheme = ColorScheme(None, "blue", "yellow", "green")
 
     )
-
 
     run_example(
         "68 On Judging (Log and Speck)",

--- a/agreement/synoptic_table.py
+++ b/agreement/synoptic_table.py
@@ -127,11 +127,6 @@ def get_colorized_text_for_tokens(colorScheme: ColorScheme, token_agreement: Lis
         ὁμοία[orange][/orange] ἐστὶν[brown][/orange] ἡ[brown][/brown] βασιλεία[brown][/brown]
         τοῦ[green][/brown] Θεοῦ[/green],[yellow] καὶ[green][/yellow] τίνι[yellow][/green]
         ὁμοιώσω[brown][/yellow] αὐτήν[/brown];"
-
-    See Also
-    --------
-    Synopsis.getData : individual analysis results that are transposed for
-    the table
     """
     prev = None
     text = rich.text.Text()

--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -2,7 +2,7 @@ from agreement.color_scheme import ColorScheme
 from agreement.color_scheme import GoodacreColorScheme
 from agreement.greek_text import GreekText
 from agreement.color_scheme import get_agreement_type
-from agreement.synoptic_table import get_color_text
+from agreement.synoptic_table import get_colorized_text_for_tokens, TokenAgreement
 from tests import config
 from tests.config import grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19
 
@@ -56,8 +56,10 @@ def test_color_Matt_13_31():
     passage = GreekText(config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31)
     pos = passage.pos
     tokens = passage.tokens
-    row = get_color_text(colorScheme, zip(pos, tokens,
-                                          agreement_type_Matt_13_31))
+    row = get_colorized_text_for_tokens(
+        colorScheme,
+        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Matt_13_31)]
+    )
     assert row == color_text
 
 
@@ -77,11 +79,11 @@ def test_color_Mark_4_30_32():
     passage = GreekText(config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30)
     pos = passage.pos
     tokens = passage.tokens
-    assert (
-        get_color_text(colorScheme, zip(pos, tokens,
-                       agreement_type_Mark_4_30_32)) == color_text
+    row = get_colorized_text_for_tokens(
+        colorScheme,
+        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Mark_4_30_32)]
     )
-
+    assert row == color_text
 
 agreement_type_Luke_13_18 = [7, 4, 0, 4, 6, 6, 7, 7, 7, 5, 0, 4, 5, 4, 7, 0]
 
@@ -98,5 +100,8 @@ def test_color_Luke_13_18():
     passage = GreekText(grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19)
     pos = passage.pos
     tokens = passage.tokens
-    assert get_color_text(colorScheme, zip(pos, tokens,
-                          agreement_type_Luke_13_18)) == color_text
+    row = get_colorized_text_for_tokens(
+        colorScheme,
+        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Luke_13_18)]
+    )
+    assert row == color_text

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -1,27 +1,52 @@
 import tests.config as config
-from agreement.synoptic_table import SynopticTable
-
+from agreement.synoptic_table import SynopticTable, Parallel
 
 def test_one_title_header():
-    synopsis = SynopticTable(
-        "291 False Christs and False Prophets",
-        [["Mark 13:21", config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21]])
-    table = synopsis.getTable()
-    assert table.title == "291 False Christs and False Prophets"
-    assert table.columns[0].header == "Mark 13:21"
-    assert table.columns[0].footer == "14 words"
+
+    TABLE_TITLE = "291 False Christs and False Prophets"
+    PASSAGES = [
+        Parallel(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21, footer="14 words")
+    ]
+
+    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    synopsis.process_synopsis()
+    table = synopsis.table
+    assert table.title == TABLE_TITLE
+    for index in range(len(PASSAGES)):
+        assert table.columns[index].header == PASSAGES[index].title
+        assert table.columns[index].footer == PASSAGES[index].footer
     assert table.row_count == 1
 
 
 def test_two_title_header():
-    synopsis = SynopticTable(
-        "291 False Christs and False Prophets",
-        [["Mark 13:21", config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21],
-         ["Matt. 24:23", config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_24_23]])
-    table = synopsis.getTable()
-    assert table.title == "291 False Christs and False Prophets"
-    assert table.columns[0].header == "Mark 13:21"
-    assert table.columns[0].footer == "14 words"
-    assert table.columns[1].header == "Matt. 24:23"
-    assert table.columns[1].footer == "13 words"
+    TABLE_TITLE = "291 False Christs and False Prophets"
+    PASSAGES = [
+        Parallel(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21, footer="14 words"),
+        Parallel(title="Matt. 24:23", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_24_23, footer="13 words")
+    ]
+
+    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    synopsis.process_synopsis()
+    table = synopsis.table
+    assert table.title == TABLE_TITLE
+    for index in range(len(PASSAGES)):
+        assert table.columns[index].header == PASSAGES[index].title
+        assert table.columns[index].footer == PASSAGES[index].footer
+    assert table.row_count == 1
+
+def test_three_title_header():
+    TABLE_TITLE = "128 The Parable of the Mustard Seed (First Verse)"
+    PASSAGES = [
+        Parallel(title="Matt. 13:31", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer="21 words"),
+        Parallel(title="Mark 4:30", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer="14 words"),
+        Parallel(title="Luke 13:18-19", text=config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="13 words"),
+    ]
+
+    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    synopsis.process_synopsis()
+    table = synopsis.table
+    assert table.title == TABLE_TITLE
+    for index in range(len(PASSAGES)):
+        assert table.columns[index].header == PASSAGES[index].title
+        assert table.columns[index].footer == PASSAGES[index].footer
     assert table.row_count == 1


### PR DESCRIPTION
Refactor and clean up bible_api.py, synoptic_table.py, test_make_table.py, and examples.py. No functional changes, other than add new test test_make_table.py::test_three_title_header

bible_api.py:
Convert construction of endpoint strings to use f-string substitutions.

synoptic_table.py: 
Change the "parallels" constructor parameter from list of lists to list of new named tuple type Parallel.
Note: I don't know if that's the best name for that type! Open to changing it.
Move the bulk of processing out of SynopticTable constructor to new method process_synopsis(), which must be called separately.
Refactor a bit of the list processing code, hopefully for improved readability.
Change SynopticTable table attribute and getTable() method to Pythonic property.

test_make_table.py:
Update use of SynopticTable per above described interface change to constructor.
Add new test_three_title_header()

examples.py:
Move repeated code into new helper function run_example().
Update use of SynopticTable per above described interface change.
