### PR TITLE
Refactor SynopticTable into SynopticTableModel and SynopicTableRichText

### DIFF
--- a/agreement/color_scheme.py
+++ b/agreement/color_scheme.py
@@ -2,17 +2,13 @@ from typing import List, Dict, NamedTuple, KeysView, Optional
 
 class ColorScheme:
     def __init__(self, *colors: Optional[str]):
-        # self._color = {}
         self._color: Dict[int, Optional[str]] = {index: colors[index] for index in range(len(colors))}
-        # for index, color in enumerate(colors):
-        #     self._color[index] = color
 
     def get_color(self, type) -> Optional[str]:
         return self._color.get(type, '')
 
     def set_color(self, type, color) -> None:
         self._color[type] = color
-
 
 
 # List of allowed Rich colors here
@@ -37,24 +33,6 @@ class GoodacreColorScheme(ColorScheme):
         brown_name = "sienna" if use_CSS_colors else "brown"
         super().set_color(get_agreement_type([column_Matthew, column_Mark,
                                                 column_Luke]), brown_name)
-
-
-
-# def GoodacreColorScheme(column_Matthew, column_Mark, column_Luke):
-#     colorScheme = ColorScheme()
-#     # https://markgoodacre.org/maze/synopses.htm
-#     colorScheme.set_color(get_agreement_type([column_Matthew]), "blue")
-#     colorScheme.set_color(get_agreement_type([column_Mark]), "red")
-#     colorScheme.set_color(get_agreement_type([column_Luke]), "yellow")
-#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark]),
-#                           "purple")
-#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Luke]),
-#                           "green")
-#     colorScheme.set_color(get_agreement_type([column_Mark, column_Luke]),
-#                           "orange")
-#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark,
-#                                               column_Luke]), "brown")
-#     return colorScheme
 
 
 def get_agreement_type(in_passage):

--- a/agreement/color_scheme.py
+++ b/agreement/color_scheme.py
@@ -1,31 +1,60 @@
-class ColorScheme:
-    def __init__(self, *colors):
-        self._color = {}
-        for index, color in enumerate(colors):
-            self._color[index] = color
+from typing import List, Dict, NamedTuple, KeysView, Optional
 
-    def get_color(self, type):
+class ColorScheme:
+    def __init__(self, *colors: Optional[str]):
+        # self._color = {}
+        self._color: Dict[int, Optional[str]] = {index: colors[index] for index in range(len(colors))}
+        # for index, color in enumerate(colors):
+        #     self._color[index] = color
+
+    def get_color(self, type) -> Optional[str]:
         return self._color.get(type, '')
 
-    def set_color(self, type, color):
+    def set_color(self, type, color) -> None:
         self._color[type] = color
 
 
-def GoodacreColorScheme(column_Matthew, column_Mark, column_Luke):
-    colorScheme = ColorScheme()
-    # https://markgoodacre.org/maze/synopses.htm
-    colorScheme.set_color(get_agreement_type([column_Matthew]), "blue")
-    colorScheme.set_color(get_agreement_type([column_Mark]), "red")
-    colorScheme.set_color(get_agreement_type([column_Luke]), "yellow")
-    colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark]),
-                          "purple")
-    colorScheme.set_color(get_agreement_type([column_Matthew, column_Luke]),
-                          "green")
-    colorScheme.set_color(get_agreement_type([column_Mark, column_Luke]),
-                          "orange")
-    colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark,
-                                              column_Luke]), "brown")
-    return colorScheme
+
+# List of allowed Rich colors here
+# https://rich.readthedocs.io/en/stable/appendix/colors.html
+
+class GoodacreColorScheme(ColorScheme):
+    def __init__(self, column_Matthew: int, column_Mark: int, column_Luke: int, use_CSS_colors: bool = False):
+        super().__init__()
+        # https://markgoodacre.org/maze/synopses.htm
+        super().set_color(get_agreement_type([column_Matthew]), "blue")
+        super().set_color(get_agreement_type([column_Mark]), "red")
+        super().set_color(get_agreement_type([column_Luke]), "yellow")
+        super().set_color(get_agreement_type([column_Matthew, column_Mark]),
+                            "purple")
+        super().set_color(get_agreement_type([column_Matthew, column_Luke]),
+                            "green")
+
+        orange_name = "orange" if use_CSS_colors else "orange"
+        super().set_color(get_agreement_type([column_Mark, column_Luke]),
+                            orange_name)
+
+        brown_name = "sienna" if use_CSS_colors else "brown"
+        super().set_color(get_agreement_type([column_Matthew, column_Mark,
+                                                column_Luke]), brown_name)
+
+
+
+# def GoodacreColorScheme(column_Matthew, column_Mark, column_Luke):
+#     colorScheme = ColorScheme()
+#     # https://markgoodacre.org/maze/synopses.htm
+#     colorScheme.set_color(get_agreement_type([column_Matthew]), "blue")
+#     colorScheme.set_color(get_agreement_type([column_Mark]), "red")
+#     colorScheme.set_color(get_agreement_type([column_Luke]), "yellow")
+#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark]),
+#                           "purple")
+#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Luke]),
+#                           "green")
+#     colorScheme.set_color(get_agreement_type([column_Mark, column_Luke]),
+#                           "orange")
+#     colorScheme.set_color(get_agreement_type([column_Matthew, column_Mark,
+#                                               column_Luke]), "brown")
+#     return colorScheme
 
 
 def get_agreement_type(in_passage):

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -2,15 +2,13 @@ from rich.console import Console
 
 from agreement.bible_api import get_chapter
 from agreement.color_scheme import ColorScheme, GoodacreColorScheme
-from agreement.config import get_report_path
-from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple
+from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple, build_synoptic_table
 from agreement.synoptic_table_rich_text import SynopticTableRichText
 import tests.config
 
 
-def run_example(table_title, passages, report_filename, color_scheme=None):
-    synopsis_model = SynopticTableModel(table_title, passages)
-    synopsis_model.process_synopsis()
+def run_example(table_title: str, passages, report_filename, color_scheme=None):
+    synopsis_model: SynopticTableModel = build_synoptic_table(table_title, passages)
     table_view = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
 
     console = Console(record=True)

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -7,19 +7,6 @@ from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple
 from agreement.synoptic_table_rich_text import SynopticTableRichText
 import tests.config
 
-# def run_example_old(table_title, passages, report_filename, **kwargs):
-#     synoptic_table = SynopticTable(
-#         table_title, passages,
-#         **kwargs
-#     )
-
-#     synoptic_table.process_synopsis()
-#     table = synoptic_table.table
-#     console = Console(record=True)
-#     console.print(table)
-#     html_path = get_report_path(report_filename)
-#     console.save_html(html_path)
-
 
 def run_example(table_title, passages, report_filename, color_scheme=None):
     synopsis_model = SynopticTableModel(table_title, passages)

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -1,5 +1,3 @@
-from rich.console import Console
-
 from agreement.bible_api import get_chapter
 from agreement.color_scheme import ColorScheme, GoodacreColorScheme
 from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple, build_synoptic_table
@@ -9,10 +7,12 @@ import tests.config
 
 def run_example(table_title: str, passages, report_filename, color_scheme=None):
     synopsis_model: SynopticTableModel = build_synoptic_table(table_title, passages)
-    table_view = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
-
-    console = Console(record=True)
-    console.print(table_view.table)
+    
+    rich_table_view = SynopticTableRichText(
+        synopsis_model,
+        color_scheme=color_scheme
+    )
+    rich_table_view.print_to_console()
 
 
 def main():

--- a/agreement/examples.py
+++ b/agreement/examples.py
@@ -3,28 +3,39 @@ from rich.console import Console
 from agreement.bible_api import get_chapter
 from agreement.color_scheme import ColorScheme, GoodacreColorScheme
 from agreement.config import get_report_path
-from agreement.synoptic_table import SynopticTable, Parallel
+from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple
+from agreement.synoptic_table_rich_text import SynopticTableRichText
 import tests.config
 
-def run_example(table_title, passages, report_filename, **kwargs):
-    synoptic_table = SynopticTable(
-        table_title, passages,
-        **kwargs
-    )
+# def run_example_old(table_title, passages, report_filename, **kwargs):
+#     synoptic_table = SynopticTable(
+#         table_title, passages,
+#         **kwargs
+#     )
 
-    synoptic_table.process_synopsis()
-    table = synoptic_table.table
+#     synoptic_table.process_synopsis()
+#     table = synoptic_table.table
+#     console = Console(record=True)
+#     console.print(table)
+#     html_path = get_report_path(report_filename)
+#     console.save_html(html_path)
+
+
+def run_example(table_title, passages, report_filename, color_scheme=None):
+    synopsis_model = SynopticTableModel(table_title, passages)
+    synopsis_model.process_synopsis()
+    table_view = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
+
     console = Console(record=True)
-    console.print(table)
-    html_path = get_report_path(report_filename)
-    console.save_html(html_path)
+    console.print(table_view.table)
+
 
 def main():
     run_example(
         "14 John's Preaching of Repentance",
         [
-            Parallel(title="Matt. 3:7-10", text=get_chapter("grc-byz1904", "καταματθαιον", 3, 7, 10), footer=""),
-            Parallel(title="Luke 3:7-9", text=get_chapter("grc-byz1904", "καταλουκαν", 3, 7, 9), footer="")
+            ParallelTuple(title="Matt. 3:7-10", text=get_chapter("grc-byz1904", "καταματθαιον", 3, 7, 10)),
+            ParallelTuple(title="Luke 3:7-9", text=get_chapter("grc-byz1904", "καταλουκαν", 3, 7, 9))
         ],
         "014-Matt+Luke.html",
         color_scheme = ColorScheme(None, "blue", "yellow", "green")
@@ -34,8 +45,8 @@ def main():
     run_example(
         "68 On Judging (Log and Speck)",
         [
-            Parallel(title="Matt. 7:3-5", text=get_chapter("grc-byz1904", "καταματθαιον", 7, 3, 5), footer=""),
-            Parallel(title="Luke 6:41-43", text=get_chapter("grc-byz1904", "καταλουκαν", 6, 41, 43), footer="")
+            ParallelTuple(title="Matt. 7:3-5", text=get_chapter("grc-byz1904", "καταματθαιον", 7, 3, 5)),
+            ParallelTuple(title="Luke 6:41-43", text=get_chapter("grc-byz1904", "καταλουκαν", 6, 41, 43))
         ],
         "068-Matt+Luke.html"
     )
@@ -43,9 +54,9 @@ def main():
     run_example(
         "128 The Parable of the Mustard Seed (First Verse)",
         [
-            Parallel(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer=""),
-            Parallel(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer=""),
-            Parallel(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="")
+            ParallelTuple(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30),
+            ParallelTuple(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31),
+            ParallelTuple(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19)
         ],
         "128-Mark+Matt+Luke.html",
         color_scheme = ColorScheme(None, None, None, "yellow", None, None, "green")
@@ -54,19 +65,19 @@ def main():
     run_example(
         "128 The Parable of the Mustard Seed (First Verse)",
         [
-            Parallel(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer=""),
-            Parallel(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer=""),
-            Parallel(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="")
+            ParallelTuple(title="Matt. 13:31", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31),
+            ParallelTuple(title="Mark 4:30", text=tests.config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30),
+            ParallelTuple(title="Luke 13:18-19", text=tests.config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19)
         ],
         "128-Matt+Mark+Luke.html",
-        color_scheme = GoodacreColorScheme(0, 1, 2)
+        color_scheme = GoodacreColorScheme(0, 1, 2, False)
     )
 
     run_example(
         "291 False Christs and False Prophets",
         [
-            Parallel(title="Mark 13:21-23", text=get_chapter("grc-byz1904", "καταμαρκον", 13, 21, 23), footer=""),
-            Parallel(title="Matt. 24:23-25", text=get_chapter("grc-byz1904", "καταματθαιον", 24, 23, 25), footer="")
+            ParallelTuple(title="Mark 13:21-23", text=get_chapter("grc-byz1904", "καταμαρκον", 13, 21, 23)),
+            ParallelTuple(title="Matt. 24:23-25", text=get_chapter("grc-byz1904", "καταματθαιον", 24, 23, 25))
          ],
         "291-Mark+Matt.svg"
     )

--- a/agreement/greek_text.py
+++ b/agreement/greek_text.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 """
 Use Classical Language Toolkit for natural language processing (NLP) with a
 general-purpose pipeline for Ancient Greek.
@@ -33,14 +35,16 @@ class GreekText:
             for i, pos in enumerate(self.doc.pos)
             if pos != "PUNCT" and self.doc.tokens[i] != "\n"
         ]
-        self._lemmata = self.doc.lemmata
+        self._lemmata: List[str] = self.doc.lemmata
         # TODO: Remove if not needed by rewritten synopsis. Otherwise document.
-        self.pos = self.doc.pos
+        self._pos: List[str] = self.doc.pos
         # TODO: Remove if not needed by rewritten synopsis. Otherwise document.
-        self.tokens = self.doc.tokens
+        self._tokens: List[str] = self.doc.tokens
+
+        self._printable_tokens: List[str] = get_printable_tokens(self._tokens, self._pos)
 
     @property
-    def clean(self):
+    def clean(self) -> List[int]:
         """
         List of indices (no text) of Greek words without newlines or
         punctuation
@@ -48,8 +52,67 @@ class GreekText:
         return self._clean
 
     @property
-    def lemmata(self):
+    def lemmata(self) -> List[str]:
         """
         List of canonical forms of each token in text
         """
         return self._lemmata
+
+    @property
+    def pos(self) -> List[str]:
+        """
+        List of parts of speech for each token in text
+        """
+        return self._pos
+
+    @property
+    def tokens(self) -> List[str]:
+        """
+        List of unprocessed (input) tokens
+        """
+        return self._tokens
+
+    @property
+    def printable_tokens(self) -> List[str]:
+        """
+        List of tokens processed for display
+        """
+        return self._printable_tokens
+
+
+def print_Greek_token(token: str, pos: str, previous: Optional[str], scripta_continua: bool=False) -> str:
+    # https://www.billmounce.com/greekalphabet/greek-punctuation-syllabification
+    # https://blog.greek-language.com/2022/02/14/punctuation-in-ancient-greek-texts-part-i/
+    # https://www.opoudjis.net/unicode/punctuation.html
+    # https://en.wikipedia.org/wiki/Ancient_Greek_grammar#Alphabet
+    retval: str
+    if pos == "PUNCT":  # token in "·,;."
+        # https://library.biblicalarchaeology.org/article/punctuationinthenewtestament/
+        # https://en.wikipedia.org/wiki/Scriptio_continua
+        if scripta_continua:
+            retval = ""
+        else:
+            retval = token
+    else:
+        if previous is None or previous == "\n" or scripta_continua:
+            retval = token
+        else:
+            retval = f" {token}"
+
+    return retval
+
+
+# Goes through the list of tokens, and based on their context in the passage, 
+# modifies each token if necessary so it can be directly printed out.
+def get_printable_tokens(tokens: List[str], pos: List[str]) -> List[str]:
+    """
+    """
+    printable_text_list: List[str] = []
+    prev_token: Optional[str] = None
+    for idx in range(len(tokens)):
+        ps=pos[idx]
+        token=tokens[idx]
+        printable = print_Greek_token(token, ps, prev_token)
+        printable_text_list.append(printable)
+        prev_token=token
+    return printable_text_list

--- a/agreement/synoptic_table_model.py
+++ b/agreement/synoptic_table_model.py
@@ -1,5 +1,4 @@
-from collections import namedtuple
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple
 
 from agreement.agreement import calculate_agreement_types
 from agreement.greek_text import GreekText
@@ -21,32 +20,11 @@ class SynopticTableModel:
     Attributes
     ----------
     """
-    def __init__(self, title: str, parallels: List[ParallelTuple]):
-        self.parallels: List[ParallelTuple] = parallels
-        self._table_title = title
-        self._column_headings: List[str] = [passage.title for passage in self.parallels]
-        self._prepared_texts: List[List[TokenAgreementTuple]]
-        self._word_counts: List[int]
-
-    def process_synopsis(self):
-        processed_greek_texts: List[GreekText] = [GreekText(passage.text) for passage in self.parallels]
-        passage_agreement_types: List[List[int]] = calculate_agreement_types(processed_greek_texts)
-
-        # 
-        self._token_agreements: List[List[TokenAgreementTuple]] = [
-            [
-                TokenAgreementTuple(pos, token, agreement_type, printable_token)
-                for pos, token, agreement_type, printable_token in zip(
-                    gt.pos,
-                    gt.tokens,
-                    passage_agreement_types[col_index],
-                    gt.printable_tokens
-                )
-            ]
-            for col_index, gt in enumerate(processed_greek_texts)
-        ]
-
-        self._word_counts: List[int] = [len(gt.clean) for gt in processed_greek_texts]
+    def __init__(self, table_title: str, column_headings: List[str], token_agreements: List[List[TokenAgreementTuple]], word_counts: List[int]):
+        self._table_title: str = table_title
+        self._column_headings: List[str] = column_headings
+        self._token_agreements: List[List[TokenAgreementTuple]] = token_agreements
+        self._word_counts: List[int] = word_counts
 
     @property
     def table_title(self) -> str:
@@ -64,3 +42,30 @@ class SynopticTableModel:
     def word_counts(self) -> List[int]:
         return self._word_counts
 
+
+def build_synoptic_table(table_title: str, parallels: List[ParallelTuple]):
+    column_headings: List[str] = [passage.title for passage in parallels]
+    
+    processed_greek_texts: List[GreekText] = [GreekText(passage.text) for passage in parallels]
+    passage_agreement_types: List[List[int]] = calculate_agreement_types(processed_greek_texts)
+    token_agreements: List[List[TokenAgreementTuple]] = [
+        [
+            TokenAgreementTuple(pos, token, agreement_type, printable_token)
+            for pos, token, agreement_type, printable_token in zip(
+                gt.pos,
+                gt.tokens,
+                passage_agreement_types[col_index],
+                gt.printable_tokens
+            )
+        ]
+        for col_index, gt in enumerate(processed_greek_texts)
+    ]
+
+    word_counts: List[int] = [len(gt.clean) for gt in processed_greek_texts]
+
+    return SynopticTableModel(
+        table_title,
+        column_headings,
+        token_agreements,
+        word_counts
+    )

--- a/agreement/synoptic_table_model.py
+++ b/agreement/synoptic_table_model.py
@@ -1,0 +1,102 @@
+from collections import namedtuple
+from typing import List, Tuple, NamedTuple, Optional
+
+from agreement.agreement import calculate_agreement_types
+from agreement.greek_text import GreekText
+
+class ParallelTuple(NamedTuple):
+    title: str # Title of a column in an agreement table
+    text: str # Body text for one column in agreement table
+
+class TokenAgreementTuple(NamedTuple):
+    pos: str # part of speech
+    token: str # greek word
+    agreement_type: int # numeric code for agreement type, which is translated to color
+
+
+class SynopticTableModel:
+    """
+    A synopsis of passages and text.
+
+    Attributes
+    ----------
+    """
+    def __init__(self, title: str, parallels: List[ParallelTuple]):
+        self.parallels: List[ParallelTuple] = parallels
+        self._table_title = title
+        self._column_headings: List[str] = [passage.title for passage in self.parallels]
+        self._prepared_texts: List[List[TokenAgreementTuple]]
+        self._word_counts: List[int]
+
+    def process_synopsis(self):
+        processed_greek_texts: List[GreekText] = [GreekText(passage.text) for passage in self.parallels]
+        passage_agreement_types: List[List[int]] = calculate_agreement_types(processed_greek_texts)
+
+        self._token_agreements: List[List[TokenAgreementTuple]] = []
+        for index in range(len(passage_agreement_types)):
+            ta_tuples = zip(
+                processed_greek_texts[index].pos, # part of speech
+                processed_greek_texts[index].tokens, # greek word
+                passage_agreement_types[index] # numeric code for agreement type, which is translated to color
+            )
+            self._token_agreements.append([TokenAgreementTuple(*z) for z in ta_tuples])
+
+        # This is for Rich rendering, doesn't belong in the model
+        # self._prepared_texts: List[List[TokenAgreementTuple]] = [
+        #     prepare_tokens(ta) for ta in token_agreements
+        # ]
+
+        self._word_counts: List[int] = [len(gt.clean) for gt in processed_greek_texts]
+
+    @property
+    def table_title(self) -> str:
+        return self._table_title
+
+    @property
+    def column_headings(self) -> List[str]:
+        return self._column_headings
+
+    # This should not be here, it's part of rendering. Just return TokenAgreementTuples
+    # @property
+    # def prepared_texts(self) -> List[List[TokenAgreementTuple]]:
+    #     return self._prepared_texts
+
+    @property
+    def token_agreements(self) -> List[List[TokenAgreementTuple]]:
+        return self._token_agreements
+
+    @property
+    def word_counts(self) -> List[int]:
+        return self._word_counts
+
+# Made the mistake of thinking this belonged here. We're still going to have to do something similar
+# for HTML, but not sure how. In the meantime, this all moves to synoptic_table_rich.py.
+# 
+# def prepare_tokens(token_agreement: List[TokenAgreementTuple]) -> List[TokenAgreementTuple]:
+#     prev: Optional[str] = None
+#     prepared_tokens: List[TokenAgreementTuple] = []
+#     for pos, token, agreement_type in token_agreement:
+#         to_print = print_Greek_token(token, pos, prev)
+#         prepared_tokens.append(TokenAgreementTuple(to_print, agreement_type))
+#         prev = token
+#     return prepared_tokens
+
+# def print_Greek_token(token: str, pos: str, previous: Optional[str], scripta_continua: bool = False) -> str:
+#     # https://www.billmounce.com/greekalphabet/greek-punctuation-syllabification
+#     # https://blog.greek-language.com/2022/02/14/punctuation-in-ancient-greek-texts-part-i/
+#     # https://www.opoudjis.net/unicode/punctuation.html
+#     # https://en.wikipedia.org/wiki/Ancient_Greek_grammar#Alphabet
+#     if pos == "PUNCT":  # token in "·,;."
+#         # https://library.biblicalarchaeology.org/article/punctuationinthenewtestament/
+#         # https://en.wikipedia.org/wiki/Scriptio_continua
+#         if scripta_continua:
+#             return ""
+#         else:
+#             return token
+#     else:
+#         if previous is None or previous == "\n" or scripta_continua:
+#             return token
+#         else:
+#             return " " + token
+
+

--- a/agreement/synoptic_table_model.py
+++ b/agreement/synoptic_table_model.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import List, Tuple, NamedTuple, Optional
+from typing import List, NamedTuple, Optional
 
 from agreement.agreement import calculate_agreement_types
 from agreement.greek_text import GreekText
@@ -12,7 +12,7 @@ class TokenAgreementTuple(NamedTuple):
     pos: str # part of speech
     token: str # greek word
     agreement_type: int # numeric code for agreement type, which is translated to color
-
+    printable_text: str # Greek token ready for display (but without color).
 
 class SynopticTableModel:
     """
@@ -32,14 +32,19 @@ class SynopticTableModel:
         processed_greek_texts: List[GreekText] = [GreekText(passage.text) for passage in self.parallels]
         passage_agreement_types: List[List[int]] = calculate_agreement_types(processed_greek_texts)
 
-        self._token_agreements: List[List[TokenAgreementTuple]] = []
-        for index in range(len(passage_agreement_types)):
-            ta_tuples = zip(
-                processed_greek_texts[index].pos, # part of speech
-                processed_greek_texts[index].tokens, # greek word
-                passage_agreement_types[index] # numeric code for agreement type, which is translated to color
-            )
-            self._token_agreements.append([TokenAgreementTuple(*z) for z in ta_tuples])
+        # 
+        self._token_agreements: List[List[TokenAgreementTuple]] = [
+            [
+                TokenAgreementTuple(pos, token, agreement_type, printable_token)
+                for pos, token, agreement_type, printable_token in zip(
+                    gt.pos,
+                    gt.tokens,
+                    passage_agreement_types[col_index],
+                    gt.printable_tokens
+                )
+            ]
+            for col_index, gt in enumerate(processed_greek_texts)
+        ]
 
         self._word_counts: List[int] = [len(gt.clean) for gt in processed_greek_texts]
 

--- a/agreement/synoptic_table_model.py
+++ b/agreement/synoptic_table_model.py
@@ -41,11 +41,6 @@ class SynopticTableModel:
             )
             self._token_agreements.append([TokenAgreementTuple(*z) for z in ta_tuples])
 
-        # This is for Rich rendering, doesn't belong in the model
-        # self._prepared_texts: List[List[TokenAgreementTuple]] = [
-        #     prepare_tokens(ta) for ta in token_agreements
-        # ]
-
         self._word_counts: List[int] = [len(gt.clean) for gt in processed_greek_texts]
 
     @property
@@ -56,11 +51,6 @@ class SynopticTableModel:
     def column_headings(self) -> List[str]:
         return self._column_headings
 
-    # This should not be here, it's part of rendering. Just return TokenAgreementTuples
-    # @property
-    # def prepared_texts(self) -> List[List[TokenAgreementTuple]]:
-    #     return self._prepared_texts
-
     @property
     def token_agreements(self) -> List[List[TokenAgreementTuple]]:
         return self._token_agreements
@@ -68,35 +58,4 @@ class SynopticTableModel:
     @property
     def word_counts(self) -> List[int]:
         return self._word_counts
-
-# Made the mistake of thinking this belonged here. We're still going to have to do something similar
-# for HTML, but not sure how. In the meantime, this all moves to synoptic_table_rich.py.
-# 
-# def prepare_tokens(token_agreement: List[TokenAgreementTuple]) -> List[TokenAgreementTuple]:
-#     prev: Optional[str] = None
-#     prepared_tokens: List[TokenAgreementTuple] = []
-#     for pos, token, agreement_type in token_agreement:
-#         to_print = print_Greek_token(token, pos, prev)
-#         prepared_tokens.append(TokenAgreementTuple(to_print, agreement_type))
-#         prev = token
-#     return prepared_tokens
-
-# def print_Greek_token(token: str, pos: str, previous: Optional[str], scripta_continua: bool = False) -> str:
-#     # https://www.billmounce.com/greekalphabet/greek-punctuation-syllabification
-#     # https://blog.greek-language.com/2022/02/14/punctuation-in-ancient-greek-texts-part-i/
-#     # https://www.opoudjis.net/unicode/punctuation.html
-#     # https://en.wikipedia.org/wiki/Ancient_Greek_grammar#Alphabet
-#     if pos == "PUNCT":  # token in "·,;."
-#         # https://library.biblicalarchaeology.org/article/punctuationinthenewtestament/
-#         # https://en.wikipedia.org/wiki/Scriptio_continua
-#         if scripta_continua:
-#             return ""
-#         else:
-#             return token
-#     else:
-#         if previous is None or previous == "\n" or scripta_continua:
-#             return token
-#         else:
-#             return " " + token
-
 

--- a/agreement/synoptic_table_rich_text.py
+++ b/agreement/synoptic_table_rich_text.py
@@ -1,5 +1,6 @@
 import rich
 from rich.table import Table
+from rich.console import Console
 from typing import List, Optional
 
 from agreement.color_scheme import ColorScheme
@@ -20,6 +21,7 @@ class SynopticTableRichText:
 
     def __init__(self, table_model: SynopticTableModel, color_scheme: Optional[ColorScheme]=None):
         self._table_model = table_model
+        self._rich_console = None
 
         self._color_scheme: Optional[ColorScheme]
         if (color_scheme == None):
@@ -52,6 +54,15 @@ class SynopticTableRichText:
 
         self._table.add_row(*cells)
 
+
+    def print_to_console(self):
+        if self._rich_console is None:
+            self._rich_console = Console(record=True)
+        self._rich_console.print(self._table)
+
+
+    # Leaving here for testing, but no longer intended to be used.
+    # Call print_to_console.
     @property
     def table(self):
         """

--- a/agreement/synoptic_table_rich_text.py
+++ b/agreement/synoptic_table_rich_text.py
@@ -1,11 +1,8 @@
 import rich
 from rich.table import Table
-from collections import namedtuple
 from typing import List, Optional
 
-from agreement.agreement import calculate_agreement_types
 from agreement.color_scheme import ColorScheme
-from agreement.greek_text import GreekText
 from agreement.synoptic_table_model import SynopticTableModel, TokenAgreementTuple
 
 
@@ -49,7 +46,6 @@ class SynopticTableRichText:
             for count in self._table_model.word_counts
         ]
 
-
         for index in range(len(self._table_model.column_headings)):
             self._table.add_column(
                 header=self._table_model.column_headings[index],
@@ -77,26 +73,7 @@ class SynopticTableRichText:
         return self._table
 
 
-def print_Greek_token(token, pos, previous, scripta_continua=False):
-    # https://www.billmounce.com/greekalphabet/greek-punctuation-syllabification
-    # https://blog.greek-language.com/2022/02/14/punctuation-in-ancient-greek-texts-part-i/
-    # https://www.opoudjis.net/unicode/punctuation.html
-    # https://en.wikipedia.org/wiki/Ancient_Greek_grammar#Alphabet
-    if pos == "PUNCT":  # token in "·,;."
-        # https://library.biblicalarchaeology.org/article/punctuationinthenewtestament/
-        # https://en.wikipedia.org/wiki/Scriptio_continua
-        if scripta_continua:
-            return ""
-        else:
-            return token
-    else:
-        if previous is None or previous == "\n" or scripta_continua:
-            return token
-        else:
-            return " " + token
-
-
-def get_colorized_text_for_tokens(colorScheme: ColorScheme, token_agreement: List[TokenAgreementTuple]) -> str:
+def get_colorized_text_for_tokens(colorScheme: ColorScheme, token_agreements: List[TokenAgreementTuple]) -> str:
     """
     Get a string of text marked up with colors showing agreement type, for a 
     single column of an agreements table.
@@ -121,11 +98,8 @@ def get_colorized_text_for_tokens(colorScheme: ColorScheme, token_agreement: Lis
         τοῦ[green][/brown] Θεοῦ[/green],[yellow] καὶ[green][/yellow] τίνι[yellow][/green]
         ὁμοιώσω[brown][/yellow] αὐτήν[/brown];"
     """
-    prev = None
     text = rich.text.Text()
-    for pos, token, agreement_type in token_agreement:
-        to_print = print_Greek_token(token, pos, prev)
+    for pos, token, agreement_type, printable_text in token_agreements:
         style = colorScheme.get_color(agreement_type)
-        text.append(to_print, style=style)
-        prev = token
+        text.append(printable_text, style=style)
     return text.markup

--- a/agreement/synoptic_table_rich_text.py
+++ b/agreement/synoptic_table_rich_text.py
@@ -8,11 +8,6 @@ from agreement.color_scheme import ColorScheme
 from agreement.greek_text import GreekText
 from agreement.synoptic_table_model import SynopticTableModel, TokenAgreementTuple
 
-# TokenAgreement = namedtuple('TokenAgreement', [
-#     'pos', # part of speech
-#     'token', # greek word
-#     'agreement_type' # numeric code for agreement type, which is translated to color
-# ])
 
 class SynopticTableRichText:
     """
@@ -28,7 +23,7 @@ class SynopticTableRichText:
 
     def __init__(self, table_model: SynopticTableModel, color_scheme: Optional[ColorScheme]=None):
         self._table_model = table_model
-        # self._color_scheme = color_scheme
+
         self._color_scheme: Optional[ColorScheme]
         if (color_scheme == None):
                 self._color_scheme = self._default_color_scheme
@@ -36,11 +31,9 @@ class SynopticTableRichText:
                 self._color_scheme = color_scheme
         assert self._color_scheme is not None
 
-        # self.parallels = parallels
         self._parallels = table_model.parallels
 
         self._table = Table(show_footer=True)
-        # self.table.title = title
         self._table.title = table_model.table_title
         token_agreements = self._table_model.token_agreements
         cells = [
@@ -64,33 +57,6 @@ class SynopticTableRichText:
             )
 
         self._table.add_row(*cells)
-
-    # def process_synopsis(self):
-    #     passage_titles = [passage.title for passage in self.parallels]
-    #     agreement_types = calculate_agreement_types(greek_texts)
-    #     greek_texts = [GreekText(passage.text) for passage in self.parallels]
-
-    #     cells = [
-    #         get_colorized_text_for_tokens(
-    #             self._color_scheme,
-    #             [TokenAgreementTuple(*t) for t in zip(
-    #                 greek_texts[index].pos, # part of speech
-    #                 greek_texts[index].tokens, # greek word
-    #                 agreement_type # numeric code for agreement type, which is translated to color
-    #             )]
-    #         )
-    #         for index, agreement_type in enumerate(agreement_types)
-    #     ]
-
-    #     descriptions = [
-    #         f"{len(greek_texts[index].clean)} words"
-    #         for index in range(len(greek_texts))
-    #     ]
-
-    #     for index, passage in enumerate(passage_titles):
-    #         self.table.add_column(header=passage, footer=descriptions[index])
-
-    #     self.table.add_row(*cells)
 
     @property
     def table(self):

--- a/agreement/synoptic_table_rich_text.py
+++ b/agreement/synoptic_table_rich_text.py
@@ -28,8 +28,6 @@ class SynopticTableRichText:
                 self._color_scheme = color_scheme
         assert self._color_scheme is not None
 
-        self._parallels = table_model.parallels
-
         self._table = Table(show_footer=True)
         self._table.title = table_model.table_title
         token_agreements = self._table_model.token_agreements

--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -13,7 +13,19 @@ from tests.config import grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19
 def assert_color_scheme(passage: GreekText, agreement_types: List[int], color_scheme: ColorScheme, color_text: str):
     pos = passage.pos
     tokens = passage.tokens
-    token_agreements = [TokenAgreementTuple(*t) for t in zip(pos, tokens, agreement_types)]
+
+    # token_agreements = [TokenAgreementTuple(*t) for t in zip(pos, tokens, agreement_types)]
+    
+    token_agreements = [
+        TokenAgreementTuple(pos, token, agreement_type, printable_token)
+        for pos, token, agreement_type, printable_token in zip(
+            passage.pos,
+            passage.tokens,
+            agreement_types,
+            passage.printable_tokens
+        )
+    ]
+
     row = get_colorized_text_for_tokens(color_scheme, token_agreements)
     assert row == color_text
 

--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -64,32 +64,8 @@ def test_color_Matt_13_31():
     colorScheme.set_color(get_agreement_type([column_Matthew, column_Luke]),
                           "orange")
 
-    # Here we have a bit of a challenge, because this would be where, in 
-    # SynopticTableModel, we take all three columns of text, and
-    # compute the agreement types. The output of SynopticTableModel
-    # is a list of TokenAgreementTuples, each of which has 
-    # the token, part of speech, and agreement type for that token
-    #
-    # The GreekText class is the tokenized text, exposing two lists, 
-    # one "lemmata" (the lemmatized words), the other "clean", a list
-    # of indices into the tokens. If an index is in the list, then
-    # that token is an actual lemmatized word, not punctuation or newline
-    #
     passage = GreekText(config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31)
 
-    # Here we cheat a bit. passage (a GreekText) doesn't properly expose pos or tokens.
-    # Need to figure out if that's needed or not
-
-    # It looks like what we're doing here is first building the list of tuples that
-    # needs to be passed to get_colorized_text_for_tokens, bypassing the normal
-    # processing of agreement types. 
-    # I really don't think this belongs in this test, but we'll have to give it
-    # another look.
-    # pos = passage.pos  # the list of parts of speech
-    # tokens = passage.tokens  # the list of raw tokens
-    # token_agreements = [TokenAgreementTuple(*t) for t in zip(pos, tokens, agreement_type_Matt_13_31)]
-    # row = get_colorized_text_for_tokens(colorScheme, token_agreements)
-    # assert row == color_text
     assert_color_scheme(passage, agreement_type_Matt_13_31, colorScheme, color_text)
 
 

--- a/tests/test_color_scheme.py
+++ b/tests/test_color_scheme.py
@@ -1,11 +1,21 @@
+from typing import List
+
 from agreement.color_scheme import ColorScheme
 from agreement.color_scheme import GoodacreColorScheme
 from agreement.greek_text import GreekText
 from agreement.color_scheme import get_agreement_type
-from agreement.synoptic_table import get_colorized_text_for_tokens, TokenAgreement
+from agreement.synoptic_table_rich_text import get_colorized_text_for_tokens
+from agreement.synoptic_table_model import TokenAgreementTuple
 from tests import config
 from tests.config import grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19
 
+
+def assert_color_scheme(passage: GreekText, agreement_types: List[int], color_scheme: ColorScheme, color_text: str):
+    pos = passage.pos
+    tokens = passage.tokens
+    token_agreements = [TokenAgreementTuple(*t) for t in zip(pos, tokens, agreement_types)]
+    row = get_colorized_text_for_tokens(color_scheme, token_agreements)
+    assert row == color_text
 
 def test_agreement_type():
     assert get_agreement_type([]) == 0  # e.g., punctuation
@@ -53,14 +63,34 @@ def test_color_Matt_13_31():
     # https://en.wikipedia.org/wiki/Synoptic_Gospels#Double_tradition
     colorScheme.set_color(get_agreement_type([column_Matthew, column_Luke]),
                           "orange")
+
+    # Here we have a bit of a challenge, because this would be where, in 
+    # SynopticTableModel, we take all three columns of text, and
+    # compute the agreement types. The output of SynopticTableModel
+    # is a list of TokenAgreementTuples, each of which has 
+    # the token, part of speech, and agreement type for that token
+    #
+    # The GreekText class is the tokenized text, exposing two lists, 
+    # one "lemmata" (the lemmatized words), the other "clean", a list
+    # of indices into the tokens. If an index is in the list, then
+    # that token is an actual lemmatized word, not punctuation or newline
+    #
     passage = GreekText(config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31)
-    pos = passage.pos
-    tokens = passage.tokens
-    row = get_colorized_text_for_tokens(
-        colorScheme,
-        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Matt_13_31)]
-    )
-    assert row == color_text
+
+    # Here we cheat a bit. passage (a GreekText) doesn't properly expose pos or tokens.
+    # Need to figure out if that's needed or not
+
+    # It looks like what we're doing here is first building the list of tuples that
+    # needs to be passed to get_colorized_text_for_tokens, bypassing the normal
+    # processing of agreement types. 
+    # I really don't think this belongs in this test, but we'll have to give it
+    # another look.
+    # pos = passage.pos  # the list of parts of speech
+    # tokens = passage.tokens  # the list of raw tokens
+    # token_agreements = [TokenAgreementTuple(*t) for t in zip(pos, tokens, agreement_type_Matt_13_31)]
+    # row = get_colorized_text_for_tokens(colorScheme, token_agreements)
+    # assert row == color_text
+    assert_color_scheme(passage, agreement_type_Matt_13_31, colorScheme, color_text)
 
 
 agreement_type_Mark_4_30_32 = [1, 7, 0, 1, 1, 7, 7, 7, 5, 0, 1, 3, 5, 1, 1,
@@ -77,13 +107,8 @@ def test_color_Mark_4_30_32():
     colorScheme = ColorScheme(None, "blue", "red", "purple",
                               "green", None, None, "black on white")
     passage = GreekText(config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30)
-    pos = passage.pos
-    tokens = passage.tokens
-    row = get_colorized_text_for_tokens(
-        colorScheme,
-        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Mark_4_30_32)]
-    )
-    assert row == color_text
+
+    assert_color_scheme(passage, agreement_type_Mark_4_30_32, colorScheme, color_text)
 
 agreement_type_Luke_13_18 = [7, 4, 0, 4, 6, 6, 7, 7, 7, 5, 0, 4, 5, 4, 7, 0]
 
@@ -100,8 +125,5 @@ def test_color_Luke_13_18():
     passage = GreekText(grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19)
     pos = passage.pos
     tokens = passage.tokens
-    row = get_colorized_text_for_tokens(
-        colorScheme,
-        [TokenAgreement(*t) for t in zip(pos, tokens, agreement_type_Luke_13_18)]
-    )
-    assert row == color_text
+
+    assert_color_scheme(passage, agreement_type_Luke_13_18, colorScheme, color_text)

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -26,14 +26,6 @@ def test_one_title_header():
 
     table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
     assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
-    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    # synopsis.process_synopsis()
-    # table = synopsis.table
-    # assert table.title == TABLE_TITLE
-    # for index in range(len(PASSAGES)):
-    #     assert table.columns[index].header == PASSAGES[index].title
-    #     assert table.columns[index].footer == PASSAGES[index].footer
-    # assert table.row_count == 1
 
 
 def test_two_title_header():
@@ -46,14 +38,7 @@ def test_two_title_header():
 
     table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
     assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
-    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    # synopsis.process_synopsis()
-    # table = synopsis.table
-    # assert table.title == TABLE_TITLE
-    # for index in range(len(PASSAGES)):
-    #     assert table.columns[index].header == PASSAGES[index].title
-    #     assert table.columns[index].footer == PASSAGES[index].footer
-    # assert table.row_count == 1
+
 
 def test_three_title_header():
     TABLE_TITLE = "128 The Parable of the Mustard Seed (First Verse)"
@@ -66,12 +51,3 @@ def test_three_title_header():
 
     table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
     assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
-
-    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    # synopsis.process_synopsis()
-    # table = synopsis.table
-    # assert table.title == TABLE_TITLE
-    # for index in range(len(PASSAGES)):
-    #     assert table.columns[index].header == PASSAGES[index].title
-    #     assert table.columns[index].footer == PASSAGES[index].footer
-    # assert table.row_count == 1

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -1,10 +1,9 @@
 import tests.config as config
-from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple
+from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple, build_synoptic_table
 from agreement.synoptic_table_rich_text import SynopticTableRichText
 
 def render_table(table_title, passages, footers, color_scheme=None):
-    synopsis_model = SynopticTableModel(table_title, passages)
-    synopsis_model.process_synopsis()
+    synopsis_model: SynopticTableModel = build_synoptic_table(table_title, passages)
     rich_synoptic_table = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
     table = rich_synoptic_table.table
     return table

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -1,52 +1,77 @@
 import tests.config as config
-from agreement.synoptic_table import SynopticTable, Parallel
+from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple
+from agreement.synoptic_table_rich_text import SynopticTableRichText
+
+def render_table(table_title, passages, footers, color_scheme=None):
+    synopsis_model = SynopticTableModel(table_title, passages)
+    synopsis_model.process_synopsis()
+    rich_synoptic_table = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
+    table = rich_synoptic_table.table
+    return table
+    
+def assert_table(table, table_title, passages, footers):
+    assert table.title == table_title
+    for index in range(len(passages)):
+        assert table.columns[index].header == passages[index].title
+        assert table.columns[index].footer == footers[index]
+    assert table.row_count == 1
 
 def test_one_title_header():
 
     TABLE_TITLE = "291 False Christs and False Prophets"
     PASSAGES = [
-        Parallel(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21, footer="14 words")
+        ParallelTuple(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21)
     ]
+    FOOTERS = ["14 words"]
 
-    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    synopsis.process_synopsis()
-    table = synopsis.table
-    assert table.title == TABLE_TITLE
-    for index in range(len(PASSAGES)):
-        assert table.columns[index].header == PASSAGES[index].title
-        assert table.columns[index].footer == PASSAGES[index].footer
-    assert table.row_count == 1
+    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    # synopsis.process_synopsis()
+    # table = synopsis.table
+    # assert table.title == TABLE_TITLE
+    # for index in range(len(PASSAGES)):
+    #     assert table.columns[index].header == PASSAGES[index].title
+    #     assert table.columns[index].footer == PASSAGES[index].footer
+    # assert table.row_count == 1
 
 
 def test_two_title_header():
     TABLE_TITLE = "291 False Christs and False Prophets"
     PASSAGES = [
-        Parallel(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21, footer="14 words"),
-        Parallel(title="Matt. 24:23", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_24_23, footer="13 words")
+        ParallelTuple(title="Mark 13:21", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_13_21),
+        ParallelTuple(title="Matt. 24:23", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_24_23)
     ]
+    FOOTERS = ["14 words", "13 words"]
 
-    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    synopsis.process_synopsis()
-    table = synopsis.table
-    assert table.title == TABLE_TITLE
-    for index in range(len(PASSAGES)):
-        assert table.columns[index].header == PASSAGES[index].title
-        assert table.columns[index].footer == PASSAGES[index].footer
-    assert table.row_count == 1
+    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    # synopsis.process_synopsis()
+    # table = synopsis.table
+    # assert table.title == TABLE_TITLE
+    # for index in range(len(PASSAGES)):
+    #     assert table.columns[index].header == PASSAGES[index].title
+    #     assert table.columns[index].footer == PASSAGES[index].footer
+    # assert table.row_count == 1
 
 def test_three_title_header():
     TABLE_TITLE = "128 The Parable of the Mustard Seed (First Verse)"
     PASSAGES = [
-        Parallel(title="Matt. 13:31", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31, footer="21 words"),
-        Parallel(title="Mark 4:30", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30, footer="14 words"),
-        Parallel(title="Luke 13:18-19", text=config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19, footer="13 words"),
+        ParallelTuple(title="Matt. 13:31", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΤΘΑΙΟΝ_13_31),
+        ParallelTuple(title="Mark 4:30", text=config.grc_byz1904_ΚΑΤΑ_ΜΑΡΚΟΝ_4_30),
+        ParallelTuple(title="Luke 13:18-19", text=config.grc_byz1904_ΚΑΤΑ_ΛΟΥΚΑΝ_13_18_19),
     ]
+    FOOTERS = ["21 words", "14 words", "13 words"]
 
-    synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
-    synopsis.process_synopsis()
-    table = synopsis.table
-    assert table.title == TABLE_TITLE
-    for index in range(len(PASSAGES)):
-        assert table.columns[index].header == PASSAGES[index].title
-        assert table.columns[index].footer == PASSAGES[index].footer
-    assert table.row_count == 1
+    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+
+    # synopsis = SynopticTable(TABLE_TITLE, PASSAGES)
+    # synopsis.process_synopsis()
+    # table = synopsis.table
+    # assert table.title == TABLE_TITLE
+    # for index in range(len(PASSAGES)):
+    #     assert table.columns[index].header == PASSAGES[index].title
+    #     assert table.columns[index].footer == PASSAGES[index].footer
+    # assert table.row_count == 1

--- a/tests/test_make_table.py
+++ b/tests/test_make_table.py
@@ -2,13 +2,11 @@ import tests.config as config
 from agreement.synoptic_table_model import SynopticTableModel, ParallelTuple, build_synoptic_table
 from agreement.synoptic_table_rich_text import SynopticTableRichText
 
-def render_table(table_title, passages, footers, color_scheme=None):
+def assert_table(table_title, passages, footers, color_scheme=None):
     synopsis_model: SynopticTableModel = build_synoptic_table(table_title, passages)
     rich_synoptic_table = SynopticTableRichText(synopsis_model, color_scheme=color_scheme)
     table = rich_synoptic_table.table
-    return table
-    
-def assert_table(table, table_title, passages, footers):
+
     assert table.title == table_title
     for index in range(len(passages)):
         assert table.columns[index].header == passages[index].title
@@ -23,8 +21,7 @@ def test_one_title_header():
     ]
     FOOTERS = ["14 words"]
 
-    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
-    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(TABLE_TITLE, PASSAGES, FOOTERS)
 
 
 def test_two_title_header():
@@ -35,8 +32,7 @@ def test_two_title_header():
     ]
     FOOTERS = ["14 words", "13 words"]
 
-    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
-    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(TABLE_TITLE, PASSAGES, FOOTERS)
 
 
 def test_three_title_header():
@@ -48,5 +44,4 @@ def test_three_title_header():
     ]
     FOOTERS = ["21 words", "14 words", "13 words"]
 
-    table = render_table(TABLE_TITLE, PASSAGES, FOOTERS)
-    assert_table(table, TABLE_TITLE, PASSAGES, FOOTERS)
+    assert_table(TABLE_TITLE, PASSAGES, FOOTERS)

--- a/tests/test_print_Greek.py
+++ b/tests/test_print_Greek.py
@@ -1,5 +1,5 @@
 # https://en.wikipedia.org/wiki/Greek_orthography#In_printing
-from agreement.synoptic_table_rich_text import print_Greek_token
+from agreement.greek_text import print_Greek_token
 
 
 def test_print_scripta_continua():

--- a/tests/test_print_Greek.py
+++ b/tests/test_print_Greek.py
@@ -1,5 +1,5 @@
 # https://en.wikipedia.org/wiki/Greek_orthography#In_printing
-from agreement.synoptic_table import print_Greek_token
+from agreement.synoptic_table_rich_text import print_Greek_token
 
 
 def test_print_scripta_continua():


### PR DESCRIPTION
SynopticTable is now separate SynopticTableModel and SynopticTableRichText. This replicates the existing functionality without intentional change. SynopticTable should be suitable for use with other views, such as direct to HTML.

This change makes #11 obsolete for now.